### PR TITLE
fix: typo in startplexamp script

### DIFF
--- a/assets/startplexamp
+++ b/assets/startplexamp
@@ -7,7 +7,7 @@ declare -a FLAGS=(--enable-gpu-rasterization --enable-zero-copy --enable-gpu-com
 if [[ "${XDG_SESSION_TYPE,,}" = "wayland" ]]; then
     echo "WAYLAND enabled, using the Wayland Electron backend"
     FEATURES="$FEATURES,UseOzonePlatform,WaylandWindowDecorations"
-    FLAGS+=(-ozone-platform=wayland)
+    FLAGS+=(--ozone-platform=wayland)
 
     # Just your normal NVIDIA things
     if [[ -c /dev/nvidia0 ]]; then


### PR DESCRIPTION
fixes apparent typo in `--ozone-platform` command line key