### PR TITLE
Update runtime

### DIFF
--- a/com.plexamp.Plexamp.yaml
+++ b/com.plexamp.Plexamp.yaml
@@ -1,11 +1,11 @@
 app-id: com.plexamp.Plexamp
 
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '23.08'
 
 command: startplexamp
 separate-locales: false
@@ -30,6 +30,8 @@ modules:
     sources:
       - type: dir
         path: .
+
+  - openssl-1.1.yaml
 
   - name: Plexamp
     buildsystem: simple

--- a/com.plexamp.Plexamp.yaml
+++ b/com.plexamp.Plexamp.yaml
@@ -36,8 +36,13 @@ modules:
     build-commands:
       - chmod +x Plexamp*.AppImage
       - ./Plexamp*.AppImage --appimage-extract
-      - install -D squashfs-root/plexamp.png /app/share/icons/hicolor/512x512/apps/com.plexamp.Plexamp.png
-      - mv squashfs-root /app/bin/plexamp
+      # Move icons into place:
+      - find squashfs-root/usr/share/ -name plexamp.png -execdir mv '{}' ./com.plexamp.Plexamp.png \;
+      - cp -rv squashfs-root/usr/share "${FLATPAK_DEST}/" && rm -rf squashfs-root/usr/share squashfs-root/plexamp.png
+      # Seem to be leftovers from the build system:
+      - find squashfs-root -depth \( -name .deps -o -name obj.target \) -exec rm -rfv '{}' \;
+      # Move everything else:
+      - mv squashfs-root "${FLATPAK_DEST}/bin/plexamp"
     sources:
       - type: file
         url: https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-4.9.5.AppImage
@@ -46,3 +51,10 @@ modules:
           is-main-source: true
           type: electron-updater
           url: https://plexamp.plex.tv/plexamp.plex.tv/desktop/latest-linux.yml
+    cleanup:
+      # Config for the self-updater? The flatpak can't self-update, anyway.
+      - app-update.yml
+      # Custom desktop file used instead.
+      - plexamp.desktop
+      # Seems to have the unpacked version next to it, but plexamp gets grumpy when removed.
+      #- app.asar

--- a/openssl-1.1.yaml
+++ b/openssl-1.1.yaml
@@ -1,0 +1,27 @@
+# Copied from
+# https://github.com/flathub/com.unity.UnityHub/blob/master/openssl-1.1.yaml
+# with changes:
+# - use the "install_sw" target
+name: openssl-1.1
+buildsystem: simple
+build-commands:
+  - ./config --prefix=/app
+  - make -j $FLATPAK_BUILDER_N_JOBS
+  - make install_sw
+cleanup:
+  - /share/doc
+  - /share/man
+  - '*.a'
+  # Don't mask CLI tools provided by runtime - we just want the versioned shared library
+  - /bin
+  # Don't mask unversion library symlinks from library
+  - /lib/libcrypto.so
+  - /lib/libssl.so
+sources:
+  - type: archive
+    url: https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+    sha256: cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
+    x-checker-data:
+      type: anitya
+      project-id: 20333
+      url-template: https://www.openssl.org/source/openssl-$version.tar.gz


### PR DESCRIPTION
As noted in #87, I figured out a way around a crash on newer runtimes.
These changes fix that and update the runtime.

It'd be much nicer if the Plexamp application were just built as a flatpak natively, but that would probably mean building it on Plex, Inc. infrastructure and then uploading to flathub. The only flatpak I know of that's done that way is Firefox. It may be something for the Plex "linux guy" to look into if there's ever spare time.