### PR TITLE
fix(env): Cursor as host

### DIFF
--- a/com.plexamp.Plexamp.yaml
+++ b/com.plexamp.Plexamp.yaml
@@ -17,6 +17,8 @@ finish-args:
   - --share=network
   - --device=dri # Needed for GPU acceleration
   - --own-name=org.mpris.MediaPlayer2.Plexamp
+  # Mouse cursor as host
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
   - name: assets


### PR DESCRIPTION
Currently on HiDPI displays the mouse cursor appears very small. Sharing the host /usr/share/icons is the solution.